### PR TITLE
fix: 解决 compare.cpp 的警告与可能的性能低问题

### DIFF
--- a/res/compare.cpp
+++ b/res/compare.cpp
@@ -112,9 +112,9 @@ pe:
     size_t to = 0, ta = 0, tc = 0;
     while (true)
     {
-        while (to < o.s && isspace(o.d[to]))
+        while (to < o.s && ig(o.d[to]))
             to++;
-        while (ta < a.s && isspace(a.d[ta]))
+        while (ta < a.s && ig(a.d[ta]))
             ta++;
         bool eo = to >= o.s, ea = ta >= a.s;
         if (eo && ea)
@@ -123,12 +123,12 @@ pe:
             quitf(_wa, "Token count differs");
         tc++;
         unsigned char *so = o.d + to, *sa = a.d + ta;
-        while (to < o.s && !isspace(o.d[to]))
+        while (to < o.s && !ig(o.d[to]))
             to++;
-        while (ta < a.s && !isspace(a.d[ta]))
+        while (ta < a.s && !ig(a.d[ta]))
             ta++;
         size_t lo = to - (so - o.d), la = ta - (sa - a.d);
         if (lo != la || memcmp(so, sa, lo) != 0)
-            quitf(_wa, "Token #%u expected '%s' found '%s'", tc, ts(sa, la).c_str(), ts(so, lo).c_str());
+            quitf(_wa, "Token #%lu expected '%s' found '%s'", tc, ts(sa, la).c_str(), ts(so, lo).c_str());
     }
 }


### PR DESCRIPTION
通常 `size_t` 应该是 64 位的，因此应该用 lu 输出。这里会产生一个警告。
另外 std::isspace 使用了 locale，比手写稍慢一点，可以改为 ig
PS：其实我是来水 Contributor 的。