### PR TITLE
Fix code-server webview input flicker/rollback

### DIFF
--- a/src/modules/companion/submitter.ts
+++ b/src/modules/companion/submitter.ts
@@ -24,22 +24,25 @@ export class Submitter {
       'GNU G++17 7.3.0': 54,
       'GNU G++20 13.2 (64 bit, winlibs)': 89,
       'GNU G++23 14.2 (64 bit, msys2)': 91,
-    };
+    } as const;
     if (Submitter.isSubmitting) {
       Io.warn(l10n.t('A submission is already in progress.'));
       return Promise.reject(new Error('Submission already in progress'));
     }
 
     let submitLanguageId = Settings.companion.submitLanguage;
-    if (!Object.values(languageList).includes(submitLanguageId)) {
-      const choice = await window.showQuickPick(Object.keys(languageList), {
+    if (submitLanguageId === -1) {
+      const choices = Object.keys(languageList) as Array<
+        keyof typeof languageList
+      >;
+      const choice = (await window.showQuickPick(choices, {
         placeHolder: l10n.t('Choose submission language'),
-      });
+      })) as keyof typeof languageList | undefined;
       if (!choice) {
         Io.info(l10n.t('Submission cancelled.'));
         return;
       }
-      submitLanguageId = languageList[choice as keyof typeof languageList];
+      submitLanguageId = languageList[choice];
       Settings.companion.submitLanguage = submitLanguageId;
     }
 

--- a/src/modules/problems/manager/index.ts
+++ b/src/modules/problems/manager/index.ts
@@ -14,8 +14,8 @@ export default class ProblemsManager {
   ): Promise<FullProblem | null> {
     return Store.getFullProblem(path);
   }
-  public static async dataRefresh() {
-    return Store.dataRefresh();
+  public static async dataRefresh(noMsg = false, fireFs = true) {
+    return Store.dataRefresh(noMsg, fireFs);
   }
   public static async closeAll() {
     return Store.closeAll();

--- a/src/modules/problems/manager/store.ts
+++ b/src/modules/problems/manager/store.ts
@@ -56,7 +56,7 @@ class Store {
     return fullProblem;
   }
 
-  public static async dataRefresh(noMsg = false) {
+  public static async dataRefresh(noMsg = false, fireFs = true) {
     this.logger.trace('Starting data refresh');
     const activePath = getActivePath();
     const idles: FullProblem[] = this.fullProblems.filter(
@@ -94,8 +94,9 @@ class Store {
       canImport,
       isRunning: !!fullProblem?.ac,
     });
-    fullProblem &&
-      (await problemFs.fireAuthorityChange(fullProblem.problem.src.path));
+    if (fullProblem && fireFs) {
+      await problemFs.fireAuthorityChange(fullProblem.problem.src.path);
+    }
   }
 
   public static async closeAll() {

--- a/src/modules/problems/manager/tcActions.ts
+++ b/src/modules/problems/manager/tcActions.ts
@@ -78,7 +78,9 @@ export class TcActions {
       return;
     }
     fullProblem.problem.tcs[msg.id] = Tc.fromI(msg.tc);
-    await Store.dataRefresh(true);
+    // This message can be emitted on every keystroke from the webview.
+    // Avoid firing virtual FS change events on each update (can cause flicker in code-server).
+    await Store.dataRefresh(true, false);
   }
   public static async toggleDisable(msg: msgs.ToggleDisableMsg) {
     const fullProblem = await Store.getFullProblem(msg.activePath);

--- a/src/types/types.backend.ts
+++ b/src/types/types.backend.ts
@@ -42,19 +42,6 @@ import {
   ITcVerdict,
 } from './types';
 
-export const isRunningVerdict = (verdict?: ITcVerdict): boolean => {
-  return (
-    verdict !== undefined &&
-    ['WT', 'CP', 'CPD', 'JG', 'JGD', 'CMP'].includes(verdict.name)
-  );
-};
-export const isExpandVerdict = (verdict?: ITcVerdict): boolean => {
-  return !(
-    (verdict !== undefined && ['AC', 'SK', 'RJ'].includes(verdict.name)) ||
-    isRunningVerdict(verdict)
-  );
-};
-
 export class TcVerdict implements ITcVerdict {
   constructor(
     public name: string,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -15,13 +15,27 @@
 // You should have received a copy of the GNU General Public License
 // along with cph-ng.  If not, see <https://www.gnu.org/licenses/>.
 
-import { UUID } from 'crypto';
+import type { UUID } from 'crypto';
 
 export interface ITcVerdict {
   name: string;
   fullName: string;
   color: string;
 }
+
+export const isRunningVerdict = (verdict?: ITcVerdict): boolean => {
+  return (
+    verdict !== undefined &&
+    ['WT', 'CP', 'CPD', 'JG', 'JGD', 'CMP'].includes(verdict.name)
+  );
+};
+
+export const isExpandVerdict = (verdict?: ITcVerdict): boolean => {
+  return !(
+    (verdict !== undefined && ['AC', 'SK', 'RJ'].includes(verdict.name)) ||
+    isRunningVerdict(verdict)
+  );
+};
 
 export interface ITcIo {
   useFile: boolean;

--- a/src/webview/src/components/tcDataView.tsx
+++ b/src/webview/src/components/tcDataView.tsx
@@ -114,12 +114,33 @@ const TcDataView = ({
   const { t } = useTranslation();
   const { dispatch } = useProblemContext();
   const [copied, setCopied] = useState(false);
-  const [internalValue, setInternalValue] = useState(value);
+  const [internalValue, setInternalValue] = useState<ITcIo>(() => ({
+    useFile: value.useFile,
+    data: value.data,
+  }));
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    setInternalValue(value);
-  }, [value]);
+    setInternalValue((prev) => {
+      const next: ITcIo = { useFile: value.useFile, data: value.data };
+      if (prev.useFile === next.useFile && prev.data === next.data) {
+        return prev;
+      }
+
+      const isEditing =
+        !readOnly &&
+        textareaRef.current !== null &&
+        document.activeElement === textareaRef.current;
+
+      // When typing, keep local state to avoid flicker / rollback caused by
+      // external refreshes (notably in code-server).
+      if (isEditing && prev.useFile === next.useFile) {
+        return prev;
+      }
+
+      return next;
+    });
+  }, [value.useFile, value.data, readOnly]);
 
   useEffect(() => {
     if (autoFocus && textareaRef.current) {


### PR DESCRIPTION
Fixes an issue in code-server where typing in the CPH-NG sidebar inputs could flicker and revert text.

Key changes:
- Keep textarea input stable while the field is focused (avoid overwriting in-progress edits during refreshes).
- Fix virtual FS write decoding and use stable mtimes to prevent refresh loops.
- Reduce virtual FS change notifications during per-keystroke test case updates.
- Small type/consistency fixes found during the initial audit (submit language typing, shared verdict helpers for the webview).
