### PR TITLE
Fix runner hang, cache collisions, and companion hardening

### DIFF
--- a/src/core/langs/c.ts
+++ b/src/core/langs/c.ts
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with cph-ng.  If not, see <https://www.gnu.org/licenses/>.
 
+import { createHash } from 'crypto';
 import { type } from 'os';
 import { basename, extname, join } from 'path';
 import Logger from '@/helpers/logger';
@@ -44,10 +45,14 @@ export class LangC extends Lang {
   ): Promise<LangCompileResult> {
     this.logger.trace('compile', { src, forceCompile });
 
+    const basenameNoExt = basename(src.path, extname(src.path));
+    const pathHash = createHash('sha256')
+      .update(src.path)
+      .digest('hex')
+      .slice(0, 8);
     const outputPath = join(
       Settings.cache.directory,
-      basename(src.path, extname(src.path)) +
-        (type() === 'Windows_NT' ? '.exe' : ''),
+      `${basenameNoExt}-${pathHash}${type() === 'Windows_NT' ? '.exe' : ''}`,
     );
 
     const compiler =

--- a/src/core/langs/cpp.ts
+++ b/src/core/langs/cpp.ts
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with cph-ng.  If not, see <https://www.gnu.org/licenses/>.
 
+import { createHash } from 'crypto';
 import { type } from 'os';
 import { basename, extname, join } from 'path';
 import Logger from '@/helpers/logger';
@@ -46,10 +47,14 @@ export class LangCpp extends Lang {
   ): Promise<LangCompileResult> {
     this.logger.trace('compile', { src, forceCompile });
 
+    const basenameNoExt = basename(src.path, extname(src.path));
+    const pathHash = createHash('sha256')
+      .update(src.path)
+      .digest('hex')
+      .slice(0, 8);
     const outputPath = join(
       Settings.cache.directory,
-      basename(src.path, extname(src.path)) +
-        (type() === 'Windows_NT' ? '.exe' : ''),
+      `${basenameNoExt}-${pathHash}${type() === 'Windows_NT' ? '.exe' : ''}`,
     );
 
     const compiler =

--- a/src/core/langs/java.ts
+++ b/src/core/langs/java.ts
@@ -15,10 +15,12 @@
 // You should have received a copy of the GNU General Public License
 // along with cph-ng.  If not, see <https://www.gnu.org/licenses/>.
 
+import { createHash } from 'crypto';
 import { basename, dirname, extname, join } from 'path';
 import Logger from '@/helpers/logger';
 import Settings from '@/helpers/settings';
 import { FileWithHash } from '@/types';
+import { mkdirIfNotExists } from '@/utils/process';
 import { KnownResult, UnknownResult } from '@/utils/result';
 import {
   CompileAdditionalData,
@@ -41,10 +43,16 @@ export class LangJava extends Lang {
   ): Promise<LangCompileResult> {
     this.logger.trace('compile', { src, forceCompile });
 
-    const outputPath = join(
+    const basenameNoExt = basename(src.path, extname(src.path));
+    const pathHash = createHash('sha256')
+      .update(src.path)
+      .digest('hex')
+      .slice(0, 8);
+    const outputDir = join(
       Settings.cache.directory,
-      basename(src.path, extname(src.path)) + '.class',
+      `${basenameNoExt}-${pathHash}`,
     );
+    const outputPath = join(outputDir, `${basenameNoExt}.class`);
 
     const compiler =
       compilationSettings?.compiler ?? Settings.compilation.javaCompiler;
@@ -57,14 +65,15 @@ export class LangJava extends Lang {
       compiler + args,
       forceCompile,
     );
-    if (!skip) {
+    if (skip) {
       return new UnknownResult({ outputPath, hash });
     }
 
     const compilerArgs = args.split(/\s+/).filter(Boolean);
 
+    await mkdirIfNotExists(outputDir);
     const result = await this._executeCompiler(
-      [compiler, ...compilerArgs, '-d', Settings.cache.directory, src.path],
+      [compiler, ...compilerArgs, '-d', outputDir, src.path],
       ac,
     );
     return result instanceof KnownResult

--- a/src/core/langs/python.ts
+++ b/src/core/langs/python.ts
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with cph-ng.  If not, see <https://www.gnu.org/licenses/>.
 
+import { createHash } from 'crypto';
 import { basename, extname, join } from 'path';
 import Logger from '@/helpers/logger';
 import Settings from '@/helpers/settings';
@@ -41,9 +42,14 @@ export class LangPython extends Lang {
   ): Promise<LangCompileResult> {
     this.logger.trace('compile', { src, forceCompile });
 
+    const basenameNoExt = basename(src.path, extname(src.path));
+    const pathHash = createHash('sha256')
+      .update(src.path)
+      .digest('hex')
+      .slice(0, 8);
     const outputPath = join(
       Settings.cache.directory,
-      basename(src.path, extname(src.path)) + '.pyc',
+      `${basenameNoExt}-${pathHash}.pyc`,
     );
 
     const compiler =

--- a/src/modules/companion/server.ts
+++ b/src/modules/companion/server.ts
@@ -19,7 +19,7 @@ export class Server {
       request.on('data', (chunk) => {
         requestData += chunk;
       });
-      request.on('close', async () => {
+      request.on('end', async () => {
         Server.logger.debug('Received request', requestData);
         if (request.url === '/') {
           if (requestData.trim() === '') {
@@ -28,7 +28,7 @@ export class Server {
             try {
               await Handler.handleIncomingProblem(JSON.parse(requestData));
             } catch (e) {
-              this.logger.error('Error parsing request data', e);
+              Server.logger.error('Error parsing request data', e);
               if (e instanceof SyntaxError) {
                 Io.warn(l10n.t('Companion data is invalid JSON'));
               } else {
@@ -69,7 +69,7 @@ export class Server {
       'Companion server listen at port',
       Settings.companion.listenPort,
     );
-    Server.server.listen(Settings.companion.listenPort);
+    Server.server.listen(Settings.companion.listenPort, '127.0.0.1');
   }
 
   public static stopServer() {

--- a/src/modules/extensionManager.ts
+++ b/src/modules/extensionManager.ts
@@ -17,7 +17,7 @@
 
 import { readFile, rm } from 'fs/promises';
 import { release } from 'os';
-import { join } from 'path';
+import { join, parse, resolve } from 'path';
 import { EventEmitter } from 'stream';
 import {
   commands,
@@ -83,11 +83,20 @@ export default class ExtensionManager {
       });
 
       if (Settings.cache.cleanOnStartup) {
-        ExtensionManager.logger.info('Cleaning cache on startup');
-        await rm(Settings.cache.directory, {
-          force: true,
-          recursive: true,
-        });
+        const cacheDir = resolve(Settings.cache.directory);
+        const isRootDir = cacheDir === parse(cacheDir).root;
+        const looksLikeCphNgCache = cacheDir.toLowerCase().includes('cph-ng');
+        if (!isRootDir && looksLikeCphNgCache) {
+          ExtensionManager.logger.info('Cleaning cache on startup');
+          await rm(cacheDir, {
+            force: true,
+            recursive: true,
+          });
+        } else {
+          ExtensionManager.logger.warn('Skip cleaning cache: unsafe path', {
+            cacheDir,
+          });
+        }
       }
 
       await Cache.ensureDir();

--- a/src/modules/problems/tcFactory.ts
+++ b/src/modules/problems/tcFactory.ts
@@ -19,7 +19,7 @@ import AdmZip from 'adm-zip';
 import { existsSync } from 'fs';
 import { readdir, unlink } from 'fs/promises';
 import { orderBy } from 'natural-orderby';
-import { basename, dirname, extname, join } from 'path';
+import { basename, dirname, extname, join, resolve, sep } from 'path';
 import { l10n, window } from 'vscode';
 import Io from '@/helpers/io';
 import Settings from '@/helpers/settings';
@@ -95,6 +95,18 @@ export default class TcFactory {
       return [];
     }
     await mkdirIfNotExists(folderPath);
+
+    const normalizePath = (path: string) =>
+      process.platform === 'win32' ? path.toLowerCase() : path;
+    const baseDir = normalizePath(resolve(folderPath) + sep);
+    for (const entry of zipData.getEntries()) {
+      const entryPath = normalizePath(resolve(folderPath, entry.entryName));
+      if (!entryPath.startsWith(baseDir)) {
+        Io.error(`Zip file contains an invalid entry: ${entry.entryName}`);
+        return [];
+      }
+    }
+
     zipData.extractAllTo(folderPath, true);
     if (Settings.problem.deleteAfterUnzip) {
       await unlink(zipPath);


### PR DESCRIPTION
Fixes several issues:

- Prevents ProcessExecutor.executeWithRunner from hanging when runner output is not valid JSON
- Fixes cache path disposal on process spawn errors
- Makes compiled output paths unique per source path to avoid collisions
- Uses request 'end' instead of 'close' for Companion request handling and binds to localhost
- Adds Zip-Slip guard when extracting testcases
- Adds safety check before cleaning cache on startup
