### PR TITLE
fix: stability hardening (retargeted to refactor/di)

### DIFF
--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -186,6 +186,7 @@
   "Waiting": "等待中",
   "Waiting response from cph-submit...": "正在等待 cph-submit 的响应...",
   "Wrong Answer": "答案错误",
+  "Zip file contains an invalid entry: {entry}": "ZIP 压缩包包含非法条目：{entry}",
   "Yes": "是",
   "answer": "答案",
   "not found": "未找到",

--- a/src/core/langs/c.ts
+++ b/src/core/langs/c.ts
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with cph-ng.  If not, see <https://www.gnu.org/licenses/>.
 
+import { createHash } from 'crypto';
 import { type } from 'os';
 import { basename, extname, join } from 'path';
 import Logger from '@/helpers/logger';
@@ -45,10 +46,14 @@ export class LangC extends Lang {
   ): Promise<LangCompileResult> {
     this.logger.trace('compile', { src, forceCompile });
 
+    const basenameNoExt = basename(src.path, extname(src.path));
+    const pathHash = createHash('sha256')
+      .update(src.path)
+      .digest('hex')
+      .slice(0, 8);
     const outputPath = join(
       renderPath(Settings.cache.directory),
-      basename(src.path, extname(src.path)) +
-        (type() === 'Windows_NT' ? '.exe' : ''),
+      `${basenameNoExt}-${pathHash}${type() === 'Windows_NT' ? '.exe' : ''}`,
     );
 
     const compiler =

--- a/src/core/langs/cpp.ts
+++ b/src/core/langs/cpp.ts
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with cph-ng.  If not, see <https://www.gnu.org/licenses/>.
 
+import { createHash } from 'crypto';
 import { type } from 'os';
 import { basename, extname, join } from 'path';
 import Logger from '@/helpers/logger';
@@ -47,10 +48,14 @@ export class LangCpp extends Lang {
   ): Promise<LangCompileResult> {
     this.logger.trace('compile', { src, forceCompile });
 
+    const basenameNoExt = basename(src.path, extname(src.path));
+    const pathHash = createHash('sha256')
+      .update(src.path)
+      .digest('hex')
+      .slice(0, 8);
     const outputPath = join(
       renderPath(Settings.cache.directory),
-      basename(src.path, extname(src.path)) +
-        (type() === 'Windows_NT' ? '.exe' : ''),
+      `${basenameNoExt}-${pathHash}${type() === 'Windows_NT' ? '.exe' : ''}`,
     );
 
     const compiler =

--- a/src/core/langs/python.ts
+++ b/src/core/langs/python.ts
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with cph-ng.  If not, see <https://www.gnu.org/licenses/>.
 
+import { createHash } from 'crypto';
 import { basename, extname, join } from 'path';
 import Logger from '@/helpers/logger';
 import Settings from '@/helpers/settings';
@@ -42,9 +43,14 @@ export class LangPython extends Lang {
   ): Promise<LangCompileResult> {
     this.logger.trace('compile', { src, forceCompile });
 
+    const basenameNoExt = basename(src.path, extname(src.path));
+    const pathHash = createHash('sha256')
+      .update(src.path)
+      .digest('hex')
+      .slice(0, 8);
     const outputPath = join(
       renderPath(Settings.cache.directory),
-      basename(src.path, extname(src.path)) + '.pyc',
+      `${basenameNoExt}-${pathHash}.pyc`,
     );
 
     const compiler =

--- a/src/modules/companion/server.ts
+++ b/src/modules/companion/server.ts
@@ -19,7 +19,7 @@ export class Server {
       request.on('data', (chunk) => {
         requestData += chunk;
       });
-      request.on('close', async () => {
+      request.on('end', async () => {
         Server.logger.debug('Received request', requestData);
         if (request.url === '/') {
           if (requestData.trim() === '') {
@@ -69,7 +69,7 @@ export class Server {
       'Companion server listen at port',
       Settings.companion.listenPort,
     );
-    Server.server.listen(Settings.companion.listenPort);
+    Server.server.listen(Settings.companion.listenPort, '127.0.0.1');
   }
 
   public static stopServer() {


### PR DESCRIPTION
Retargeted to `refactor/di` per feedback on #147.\n\nFixes:\n- Prevents `ProcessExecutor.executeWithRunner` from hanging when runner output is invalid JSON\n- Fixes cache path disposal on process spawn errors\n- Makes compiled output paths unique per source path to avoid collisions\n- Uses request `end` instead of `close` for Companion request handling and binds to `127.0.0.1`\n- Adds Zip-Slip guard when extracting testcases\n- Adds safety check before cleaning cache on startup