### PR TITLE
Registered submit command

### DIFF
--- a/packages/core/src/webviewEvents.ts
+++ b/packages/core/src/webviewEvents.ts
@@ -43,6 +43,7 @@ const WebviewEventName = {
   BACKGROUND: 'BACKGROUND',
   NO_PROBLEM: 'NO_PROBLEM',
   CONFIG_CHANGE: 'CONFIG_CHANGE',
+  OPEN_SUBMIT_DIALOG: 'OPEN_SUBMIT_DIALOG',
 } as const;
 
 interface WebviewFullProblemEvent {
@@ -105,6 +106,10 @@ interface WebviewConfigChangeEvent {
   type: typeof WebviewEventName.CONFIG_CHANGE;
   payload: Partial<WebviewConfig>;
 }
+export interface WebviewOpenSubmitDialogEvent {
+  type: typeof WebviewEventName.OPEN_SUBMIT_DIALOG;
+  problemId: ProblemId;
+}
 
 export type WebviewEvent =
   | WebviewFullProblemEvent
@@ -116,4 +121,5 @@ export type WebviewEvent =
   | WebviewPatchTestcaseResultEvent
   | WebviewBackgroundEvent
   | WebviewNoProblemEvent
-  | WebviewConfigChangeEvent;
+  | WebviewConfigChangeEvent
+  | WebviewOpenSubmitDialogEvent;

--- a/packages/vscode-ext/src/application/ports/vscode/ISidebarProvider.ts
+++ b/packages/vscode-ext/src/application/ports/vscode/ISidebarProvider.ts
@@ -20,4 +20,5 @@ import type { WebviewViewProvider } from 'vscode';
 export interface ISidebarProvider extends WebviewViewProvider {
   viewType: string;
   dispatchFullConfig(): void;
+  flushPendingMessages(): void;
 }

--- a/packages/vscode-ext/src/application/ports/vscode/IWebviewEventBus.ts
+++ b/packages/vscode-ext/src/application/ports/vscode/IWebviewEventBus.ts
@@ -32,6 +32,7 @@ import type {
 
 export interface IWebviewEventBus {
   onMessage(callback: (data: WebviewEvent) => void): void;
+  openSubmitDialog(problemId: ProblemId): void;
   fullProblem(problemId: ProblemId, payload: IWebviewProblem): void;
   patchMeta(problemId: ProblemId, payload: WebviewPatchMetaPayload): void;
   patchStressTest(problemId: ProblemId, payload: WebviewPatchStressTestPayload): void;

--- a/packages/vscode-ext/src/application/useCases/webview/Init.ts
+++ b/packages/vscode-ext/src/application/useCases/webview/Init.ts
@@ -37,5 +37,6 @@ export class Init implements IMsgHandle<InitMsg> {
     this.repo.fireBackgroundEvent();
     await this.coordinator.dispatchFullData();
     this.sidebarProvider.dispatchFullConfig();
+    this.sidebarProvider.flushPendingMessages();
   }
 }

--- a/packages/vscode-ext/src/infrastructure/vscode/extensionModule/commandModule.ts
+++ b/packages/vscode-ext/src/infrastructure/vscode/extensionModule/commandModule.ts
@@ -25,10 +25,13 @@ import type { IProblemRepository } from '@/application/ports/problems/IProblemRe
 import type { IProblemService } from '@/application/ports/problems/IProblemService';
 import type { IActivePathService } from '@/application/ports/vscode/IActivePathService';
 import type { IExtensionModule } from '@/application/ports/vscode/IExtensionModule';
+import type { ISettings } from '@/application/ports/vscode/ISettings';
 import type { ITranslator } from '@/application/ports/vscode/ITranslator';
 import type { IUi } from '@/application/ports/vscode/IUi';
+import type { IWebviewEventBus } from '@/application/ports/vscode/IWebviewEventBus';
 import { CreateProblem } from '@/application/useCases/webview/problem/manage/CreateProblem';
 import { ImportProblem } from '@/application/useCases/webview/problem/manage/ImportProblem';
+import { Submit } from '@/application/useCases/webview/problem/Submit';
 import { RunAllTestcases } from '@/application/useCases/webview/problem/testcase/run/RunAllTestcases';
 import { StopTestcases } from '@/application/useCases/webview/problem/testcase/run/StopTestcases';
 import { TOKENS } from '@/composition/tokens';
@@ -43,6 +46,8 @@ export class CommandModule implements IExtensionModule {
     @inject(TOKENS.path) private readonly path: IPath,
     @inject(TOKENS.problemRepository) private readonly repo: IProblemRepository,
     @inject(TOKENS.problemService) private readonly problemService: IProblemService,
+    @inject(TOKENS.webviewEventBus) private readonly webviewEventBus: IWebviewEventBus,
+    @inject(TOKENS.settings) private readonly settings: ISettings,
     @inject(TOKENS.system) private readonly sys: ISystem,
     @inject(TOKENS.translator) private readonly translator: ITranslator,
     @inject(TOKENS.version) private readonly version: string,
@@ -52,6 +57,7 @@ export class CommandModule implements IExtensionModule {
     @inject(ImportProblem) private readonly importProblem: ImportProblem,
     @inject(RunAllTestcases) private readonly runAllTestcases: RunAllTestcases,
     @inject(StopTestcases) private readonly stopTestcases: StopTestcases,
+    @inject(Submit) private readonly submit: Submit,
   ) {}
 
   private async getProblemId() {
@@ -86,6 +92,17 @@ export class CommandModule implements IExtensionModule {
         this.ui.showSidebar();
         await this.stopTestcases.exec({
           type: 'stopTestcases',
+          problemId: await this.getProblemId(),
+        });
+      },
+      'cph-ng.submit': async () => {
+        if (this.settings.companion.confirmSubmit) {
+          this.ui.showSidebar();
+          this.webviewEventBus.openSubmitDialog(await this.getProblemId());
+          return;
+        }
+        await this.submit.exec({
+          type: 'submit',
           problemId: await this.getProblemId(),
         });
       },

--- a/packages/vscode-ext/src/infrastructure/vscode/sidebarProvider.ts
+++ b/packages/vscode-ext/src/infrastructure/vscode/sidebarProvider.ts
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with cph-ng.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { WebviewEvent } from '@cph-ng/core';
 import { inject, injectable } from 'tsyringe';
 import { Uri, type WebviewView } from 'vscode';
 import type { ILogger } from '@/application/ports/vscode/ILogger';
@@ -29,6 +30,8 @@ import { WebviewProtocolHandler } from '@/infrastructure/vscode/webviewProtocolH
 export class SidebarProvider implements ISidebarProvider {
   public readonly viewType = 'cphNgSidebar';
   private _view?: WebviewView;
+  private isReady = false;
+  private readonly pendingMessages: WebviewEvent[] = [];
 
   public constructor(
     @inject(TOKENS.extensionPath) private readonly extPath: string,
@@ -41,7 +44,8 @@ export class SidebarProvider implements ISidebarProvider {
     this.logger = this.logger.withScope('sidebarProvider');
 
     this.eventBus.onMessage((data) => {
-      this._view?.webview.postMessage(data);
+      if (this.isReady && this._view) this._view.webview.postMessage(data);
+      else this.pendingMessages.push(data);
     });
 
     this.settings.companion.onChangeConfirmSubmit((confirmSubmit) =>
@@ -71,5 +75,14 @@ export class SidebarProvider implements ISidebarProvider {
       showAcGif: this.settings.sidebar.showAcGif,
       hiddenStatuses: this.settings.sidebar.hiddenStatuses,
     });
+  }
+
+  public flushPendingMessages(): void {
+    if (!this._view) return;
+    this.isReady = true;
+    while (this.pendingMessages.length > 0) {
+      const message = this.pendingMessages.shift();
+      if (message) this._view.webview.postMessage(message);
+    }
   }
 }

--- a/packages/vscode-ext/src/infrastructure/vscode/sidebarProvider.ts
+++ b/packages/vscode-ext/src/infrastructure/vscode/sidebarProvider.ts
@@ -60,6 +60,7 @@ export class SidebarProvider implements ISidebarProvider {
   }
 
   public resolveWebviewView(webviewView: WebviewView) {
+    this.isReady = false;
     this._view = webviewView;
     webviewView.webview.options = {
       enableScripts: true,
@@ -78,11 +79,12 @@ export class SidebarProvider implements ISidebarProvider {
   }
 
   public flushPendingMessages(): void {
-    if (!this._view) return;
+    const view = this._view;
+    if (!view) return;
     this.isReady = true;
-    while (this.pendingMessages.length > 0) {
-      const message = this.pendingMessages.shift();
-      if (message) this._view.webview.postMessage(message);
+    for (const message of this.pendingMessages) {
+      view.webview.postMessage(message);
     }
+    this.pendingMessages.length = 0;
   }
 }

--- a/packages/vscode-ext/src/infrastructure/vscode/webviewEventBus.ts
+++ b/packages/vscode-ext/src/infrastructure/vscode/webviewEventBus.ts
@@ -52,6 +52,11 @@ export class WebviewEventBusAdapter implements IWebviewEventBus {
     this.emitter.on('message', handler);
   }
 
+  public openSubmitDialog(problemId: ProblemId): void {
+    this.logger.debug('Emitting openSubmitDialog event', { problemId });
+    this.emitter.emit('message', { type: 'OPEN_SUBMIT_DIALOG', problemId });
+  }
+
   public fullProblem(problemId: ProblemId, payload: IWebviewProblem): void {
     this.logger.debug('Emitting fullProblem event', { problemId, payload });
     this.emitter.emit('message', { type: 'FULL_PROBLEM', problemId, payload });

--- a/packages/vscode-webview/src/components/actions/problemActions.tsx
+++ b/packages/vscode-webview/src/components/actions/problemActions.tsx
@@ -32,7 +32,11 @@ import { CphNgButton } from '@/components/base/cphNgButton';
 import { CphNgFlex } from '@/components/base/cphNgFlex';
 import { RunButtonGroup } from '@/components/runButtonGroup';
 import { useConfigState } from '@/context/ConfigContext';
-import { useProblemDispatch } from '@/context/ProblemContext';
+import {
+  useProblemDispatch,
+  useProblemState,
+  useProblemUiDispatch,
+} from '@/context/ProblemContext';
 
 interface ProblemActionsProps {
   problemId: ProblemId;
@@ -46,10 +50,11 @@ export const ProblemActions = memo(
   ({ problemId, url, stressTest, hasRunning, backgroundProblems }: ProblemActionsProps) => {
     const { t } = useTranslation();
     const { config } = useConfigState();
+    const { submitDialogProblemId } = useProblemState();
     const dispatch = useProblemDispatch();
+    const uiDispatch = useProblemUiDispatch();
     const [clickTime, setClickTime] = useState<number[]>([]);
     const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
-    const [isSubmitDialogOpen, setSubmitDialogOpen] = useState(false);
     const [isStressTestDialogOpen, setStressTestDialogOpen] = useState(false);
 
     useEffect(() => {
@@ -107,11 +112,10 @@ export const ProblemActions = memo(
                 name={t('problemActions.submit')}
                 icon={BackupIcon}
                 color='secondary'
-                onClick={() =>
-                  config.confirmSubmit
-                    ? setSubmitDialogOpen(true)
-                    : dispatch({ type: 'submit', problemId })
-                }
+                onClick={() => {
+                  if (config.confirmSubmit) uiDispatch({ type: 'openSubmitDialog', problemId });
+                  else dispatch({ type: 'submit', problemId });
+                }}
               />
             )}
             <CphNgButton
@@ -137,11 +141,11 @@ export const ProblemActions = memo(
         />
 
         <SubmitDialog
-          open={isSubmitDialogOpen}
-          onClose={() => setSubmitDialogOpen(false)}
+          open={submitDialogProblemId === problemId}
+          onClose={() => uiDispatch({ type: 'closeSubmitDialog' })}
           onConfirm={() => {
             dispatch({ type: 'submit', problemId });
-            setSubmitDialogOpen(false);
+            uiDispatch({ type: 'closeSubmitDialog' });
           }}
         />
 

--- a/packages/vscode-webview/src/components/actions/submitDialog.tsx
+++ b/packages/vscode-webview/src/components/actions/submitDialog.tsx
@@ -21,7 +21,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
-import { memo } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface SubmitDialogProps {
@@ -32,6 +32,18 @@ interface SubmitDialogProps {
 
 export const SubmitDialog = memo(({ open, onClose, onConfirm }: SubmitDialogProps) => {
   const { t } = useTranslation();
+  const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const frameId = requestAnimationFrame(() => {
+      confirmButtonRef.current?.focus();
+    });
+
+    return () => cancelAnimationFrame(frameId);
+  }, [open]);
+
   return (
     <Dialog fullWidth maxWidth={false} open={open} onClose={onClose}>
       <DialogTitle>{t('problemActions.submitDialog.title')}</DialogTitle>
@@ -42,7 +54,7 @@ export const SubmitDialog = memo(({ open, onClose, onConfirm }: SubmitDialogProp
         <Button onClick={onClose} color='primary'>
           {t('problemActions.submitDialog.cancel')}
         </Button>
-        <Button onClick={onConfirm} color='primary' autoFocus>
+        <Button ref={confirmButtonRef} onClick={onConfirm} color='primary' autoFocus>
           {t('problemActions.submitDialog.confirm')}
         </Button>
       </DialogActions>

--- a/packages/vscode-webview/src/context/ProblemContext.tsx
+++ b/packages/vscode-webview/src/context/ProblemContext.tsx
@@ -91,16 +91,6 @@ const problemReducer = (state: State, action: WebviewEvent | WebviewMsg | Proble
       draft.submitDialogProblemId = action.problemId;
       return;
     }
-    if (action.type === 'openSubmitDialog') {
-      // This is to be used by the webview UI only
-      draft.submitDialogProblemId = action.problemId;
-      return;
-    }
-    if (action.type === 'closeSubmitDialog') {
-      // This is to be used by the webview UI only
-      draft.submitDialogProblemId = null;
-      return;
-    }
 
     if (draft.currentProblem.type !== 'active') return;
     const problem = draft.currentProblem.problem;
@@ -194,6 +184,14 @@ const problemReducer = (state: State, action: WebviewEvent | WebviewMsg | Proble
       const testcaseOrder = problem.testcaseOrder;
       const [movedTestcase] = testcaseOrder.splice(action.fromIdx, 1);
       testcaseOrder.splice(action.toIdx, 0, movedTestcase);
+      return;
+    }
+    if (action.type === 'openSubmitDialog') {
+      draft.submitDialogProblemId = action.problemId;
+      return;
+    }
+    if (action.type === 'closeSubmitDialog') {
+      draft.submitDialogProblemId = null;
       return;
     }
   });

--- a/packages/vscode-webview/src/context/ProblemContext.tsx
+++ b/packages/vscode-webview/src/context/ProblemContext.tsx
@@ -45,19 +45,26 @@ interface CurrentProblemStateActive {
 }
 type CurrentProblemState = CurrentProblemStateIdle | CurrentProblemStateActive;
 
+type ProblemUiMsg =
+  | { type: 'openSubmitDialog'; problemId: ProblemId }
+  | { type: 'closeSubmitDialog' };
+
 type State = {
   isReady: boolean;
   currentProblem: CurrentProblemState;
   backgroundProblems: IWebviewBackgroundProblem[];
+  submitDialogProblemId: ProblemId | null;
 };
 
 const StateContext = createContext<State | undefined>(undefined);
 const DispatchContext = createContext<((msg: WebviewMsg) => void) | undefined>(undefined);
+const UiDispatchContext = createContext<((msg: ProblemUiMsg) => void) | undefined>(undefined);
 
-const problemReducer = (state: State, action: WebviewEvent | WebviewMsg): State => {
+const problemReducer = (state: State, action: WebviewEvent | WebviewMsg | ProblemUiMsg): State => {
   return produce(state, (draft) => {
     if (action.type === 'FULL_PROBLEM') {
       draft.isReady = true;
+      draft.submitDialogProblemId = null;
       draft.currentProblem = {
         type: 'active',
         problemId: action.problemId,
@@ -72,11 +79,26 @@ const problemReducer = (state: State, action: WebviewEvent | WebviewMsg): State 
     }
     if (action.type === 'NO_PROBLEM') {
       draft.isReady = true;
+      draft.submitDialogProblemId = null;
       draft.currentProblem = { type: 'idle', canImport: action.canImport };
       return;
     }
     if (action.type === 'CONFIG_CHANGE') {
       // We handle this event in the ConfigContext, so we can ignore it here
+      return;
+    }
+    if (action.type === 'OPEN_SUBMIT_DIALOG') {
+      draft.submitDialogProblemId = action.problemId;
+      return;
+    }
+    if (action.type === 'openSubmitDialog') {
+      // This is to be used by the webview UI only
+      draft.submitDialogProblemId = action.problemId;
+      return;
+    }
+    if (action.type === 'closeSubmitDialog') {
+      // This is to be used by the webview UI only
+      draft.submitDialogProblemId = null;
       return;
     }
 
@@ -182,6 +204,7 @@ export const ProblemProvider = ({ children }: { children: ReactNode }) => {
     currentProblem: { type: 'idle', canImport: false },
     backgroundProblems: [],
     isReady: false,
+    submitDialogProblemId: null,
   });
 
   useEffect(() => {
@@ -196,9 +219,15 @@ export const ProblemProvider = ({ children }: { children: ReactNode }) => {
     vscode.postMessage(msg);
   }, []);
 
+  const uiDispatch = useCallback((msg: ProblemUiMsg) => {
+    reactDispatch(msg);
+  }, []);
+
   return (
     <DispatchContext.Provider value={dispatch}>
-      <StateContext.Provider value={state}>{children}</StateContext.Provider>
+      <UiDispatchContext.Provider value={uiDispatch}>
+        <StateContext.Provider value={state}>{children}</StateContext.Provider>
+      </UiDispatchContext.Provider>
     </DispatchContext.Provider>
   );
 };
@@ -212,5 +241,11 @@ export const useProblemState = () => {
 export const useProblemDispatch = () => {
   const dispatch = useContext(DispatchContext);
   if (!dispatch) throw new Error('useProblemDispatch must be used within a ProblemProvider');
+  return dispatch;
+};
+
+export const useProblemUiDispatch = () => {
+  const dispatch = useContext(UiDispatchContext);
+  if (!dispatch) throw new Error('useProblemUiDispatch must be used within a ProblemProvider');
   return dispatch;
 };


### PR DESCRIPTION
### Summary
Registered the _`cph-ng.submit`_ command.

---
### Behavior After This PR
Sending _`cph-ng.submit`_ now does the following:
* **If `confirmSubmit = false`:** submits immediately.
* **If `confirmSubmit = true`:** shows the Submit Dialog on the sidebar, focuses the "Confirm" button (so the user can hit enter to submit) and returns without an immediate submit.
---
### What Changed

**1. Added a new webview event for opening the submit dialog**
* Added `OPEN_SUBMIT_DIALOG` to the webview event contract in `webviewEvents.ts`.
* Included `problemId` payload so the dialog intent is tied to a specific problem.

**2. Extended the extension webview event bus**
* Added `openSubmitDialog(problemId)` to `IWebviewEventBus.ts`.
* Implemented the emitter logic in `webviewEventBus.ts`.

**3. Added safe message buffering in the sidebar provider**
* In `sidebarProvider.ts`: Queued outbound webview events while the sidebar is not ready, and added logic to flush queued messages after the init handshake.
* Added `flushPendingMessages()` contract in `ISidebarProvider.ts`.
* Called flush after the init sync in `Init.ts`.
