### PR TITLE
chore: pin pnpm@10.33.2 via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "license": "AGPL-3.0-only",
+  "packageManager": "pnpm@10.33.2",
   "scripts": {
     "compile": "pnpm -r --parallel compile",
     "package": "tsx scripts/package.ts",


### PR DESCRIPTION
## 背景
仓库没有 `packageManager` 字段，corepack 默认抓到 pnpm 11+，而 pnpm 11
完全移除了对 `package.json#pnpm` 的支持（`patchedDependencies` /
`onlyBuiltDependencies` / `updateConfig`），导致 `pnpm install
--frozen-lockfile` 报错：
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
CI 实际跑的是 pnpm 10（见 `.github/actions/setup-node-pnpm`），本地
corepack 却默认用 11，环境不一致。
## 改动
`package.json` 顶层新增一行：
```json
"packageManager": "pnpm@10.33.2"
```
对齐 CI，让 corepack 自动锁到 10.x。