### PR TITLE
feat(browser-ext): support submitting to Codeforces Gym problems

### DIFF
--- a/packages/browser-ext/src/submitters/codeforces.ts
+++ b/packages/browser-ext/src/submitters/codeforces.ts
@@ -22,14 +22,15 @@ import type { SubmitData } from '@cph-ng/core';
 
 export class CodeforcesSubmitter extends BaseSubmitter {
   public readonly supportedDomains = submitterDomains.codeforces;
-  private readonly contestRegex = /^\/contest\/(?<contest>\d+)\/problem\/(?<problem>\w+)/;
+  private readonly contestRegex =
+    /^\/(?<type>contest|gym)\/(?<contest>\d+)\/problem\/(?<problem>\w+)/;
   private readonly problemRegex = /^\/problemset\/problem\/(?<contest>\d+)\/(?<problem>\w+)/;
 
   public getSubmitUrl(data: SubmitData) {
     const url = new URL(data.url);
     const contest = url.pathname.match(this.contestRegex)?.groups;
     const problem = url.pathname.match(this.problemRegex)?.groups;
-    if (contest) url.pathname = `/contest/${contest.contest}/submit`;
+    if (contest) url.pathname = `/${contest.type}/${contest.contest}/submit`;
     else if (problem) url.pathname = `/problemset/submit`;
     else throw new ExtractError('type');
     return url.toString();


### PR DESCRIPTION
## Motivation

The submission pipeline already works for Codeforces Gym — only the URL regexes in `CodeforcesSubmitter` didn't match `/gym/<id>/problem/<X>`, so `getSubmitUrl` threw `ExtractError('type')`.

## Summary

Generalize `contestRegex` to also match `/gym/...` and build the submit URL as `/${type}/${contest}/submit` — a two-line change; `fill()` already works as-is since the Gym submit page uses the same form as the contest one.

## Testing

Tested against a real Gym contest: the extension opened the Gym submit page and the submission went through successfully.