### PR TITLE
fix(browser-ext): remove waitFor timeout for captcha resolution

### DIFF
--- a/packages/browser-ext/src/submitters/base.ts
+++ b/packages/browser-ext/src/submitters/base.ts
@@ -31,18 +31,11 @@ export abstract class BaseSubmitter {
         return;
       }
 
-      const deadline = Date.now() + 30000;
       const check = setInterval(() => {
         const result = condition();
         if (result) {
           clearInterval(check);
           resolve();
-          return;
-        }
-        if (Date.now() >= deadline) {
-          clearInterval(check);
-          reject(new Error('Timeout waiting for condition'));
-          return;
         }
       }, 100);
     });


### PR DESCRIPTION
有些OJ，例如codeforces验证码时间很长，有时要用上1min，而且这个超时操作在这里也意义不大，就算卡住了用户直接退出或者刷新就好了，有些时候超时了，但是验证码过了就很无语