### PR TITLE
chore(deps): upgrade pnpm to v11.21.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ out/
 node_modules/
 coverage/
 *.tsbuildinfo
+# pnpm
+.pnpm-debug.log
+.pnpm-store/

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --build",
     "lint": "biome check",
     "format": "biome check --write",
-    "clean": "pnpm -r --parallel clean && rimraf dist out scripts/out",
+    "clean": "pnpm run --parallel clean && rimraf dist out scripts/out",
     "check-translations": "pnpm -r --parallel check-translations",
     "bump": "tsx scripts/bump-version.ts",
     "prepare": "tsx scripts/install-hooks.ts"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "license": "AGPL-3.0-only",
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.21.0",
   "scripts": {
     "compile": "pnpm -r --parallel compile",
     "package": "tsx scripts/package.ts",
@@ -40,24 +40,5 @@
     "vitest": "^4.1.10",
     "webpack": "^5.109.2",
     "webpack-cli": "^7.2.2"
-  },
-  "pnpm": {
-    "patchedDependencies": {
-      "ts-json-schema-generator@2.9.0": "patches/ts-json-schema-generator.patch"
-    },
-    "updateConfig": {
-      "ignoreDependencies": [
-        "@types/vscode",
-        "@types/node"
-      ]
-    },
-    "onlyBuiltDependencies": [
-      "@getgrit/cli",
-      "@swc/core",
-      "esbuild",
-      "protobufjs",
-      "sharp",
-      "spawn-sync"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,16 +4,15 @@ packages:
 patchedDependencies:
   ts-json-schema-generator@2.9.0: patches/ts-json-schema-generator.patch
 
-onlyBuiltDependencies:
-  - "@getgrit/cli"
-  - "@swc/core"
-  - "@vscode/vsce-sign"
-  - esbuild
-  - keytar
-  - protobufjs
-  - sharp
-  - spawn-sync
-
+allowBuilds:
+  "@getgrit/cli": true
+  "@swc/core": true
+  "@vscode/vsce-sign": true
+  "esbuild": true
+  "keytar": true
+  "protobufjs": true
+  "sharp": true
+  "spawn-sync": true
 updateConfig:
   ignoreDependencies:
     - "@types/vscode"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,24 @@
 packages:
   - "packages/*"
 
+patchedDependencies:
+  ts-json-schema-generator@2.9.0: patches/ts-json-schema-generator.patch
+
+onlyBuiltDependencies:
+  - "@getgrit/cli"
+  - "@swc/core"
+  - "@vscode/vsce-sign"
+  - esbuild
+  - keytar
+  - protobufjs
+  - sharp
+  - spawn-sync
+
+updateConfig:
+  ignoreDependencies:
+    - "@types/vscode"
+    - "@types/node"
+
 fetchRetryFactor: 2
 fetchRetryMintimeout: 1000
 fetchTimeout: 30000


### PR DESCRIPTION
This pull request updates dependency management for the project by upgrading the `pnpm` package manager and moving several configuration options from `package.json` to `pnpm-workspace.yaml`. This change centralizes workspace configuration and aligns with best practices for monorepo setups.

Dependency management updates:

* Upgraded the `pnpm` version from `10.33.2` to `11.21.0` in `package.json`, ensuring compatibility with the latest features and bug fixes.
* Moved `pnpm`-specific configuration options—including `patchedDependencies`, `onlyBuiltDependencies`, and `updateConfig` (such as ignored dependencies)—from `package.json` to `pnpm-workspace.yaml` for better organization and maintainability. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L43-L61) [[2]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cR4-R21)